### PR TITLE
Include `skip-changelog` label in dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+      - "skip-changelog"


### PR DESCRIPTION
Since they are just dependency updates we never really need to be adding a changelog here. This is the most straightforward approach, rather than trying to do any ignore path stuff to try to get the job to ignore certain files and folders.