### PR TITLE
ci: pin TagBot action to a commit SHA

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@14d7645453716d7a2f09b1da0504a024f97462a1 # v1.25.10
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Edit the following line to reflect the actual name of the GitHub Secret containing your private key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [v1.0.0]: https://github.com/PumasAI/QuartoTools.jl/releases/tag/v1.0.0
 [v1.1.0]: https://github.com/PumasAI/QuartoTools.jl/releases/tag/v1.1.0
-[v1.1.2]: https://github.com/PumasAI/QuartoTools.jl/releases/tag/v1.1.2
 [v1.1.1]: https://github.com/PumasAI/QuartoTools.jl/releases/tag/v1.1.1
+[v1.1.2]: https://github.com/PumasAI/QuartoTools.jl/releases/tag/v1.1.2
 [#7]: https://github.com/PumasAI/QuartoTools.jl/issues/7
 [#25]: https://github.com/PumasAI/QuartoTools.jl/issues/25
 [#26]: https://github.com/PumasAI/QuartoTools.jl/issues/26


### PR DESCRIPTION
TagBot never ran because the org ruleset only allows SHA-pinned actions, and this was the one workflow still referencing a tag. `14d7645` is what `v1` currently points at (released as v1.25.10).
